### PR TITLE
Добавлен пропущенный completionHandler на экране СБП

### DIFF
--- a/TinkoffASDKUI/TinkoffASDKUI/AcquiringUISDK.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/AcquiringUISDK.swift
@@ -240,7 +240,8 @@ public class AcquiringUISDK: NSObject {
             guard let self = self else { return }
             if let paymentId = self.paymentInitResponseData?.paymentId {
                 let urlSBPViewController = self.urlSBPPaymentViewController(paymentSource: .paymentId(paymentId),
-                                                                            configuration: configuration)
+                                                                            configuration: configuration,
+                                                                            completionHandler: completionHandler)
                 viewController.present(urlSBPViewController, animated: true, completion: nil)
             }
         }


### PR DESCRIPTION
При открытии экрана СБП с экрана оплаты не возвращался никакой результат потому что `completionHandler` оставался `nil`, что не позволяет узнать о каком либо результате.
Добавил прокидывание  параметра `completionHandler` в функции `presentPaymentView`.