### PR TITLE
[MIC-6021] Fix logger's crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+* [MIC-6021] Fix logger's crash
+
 ## [2.8.0] - 2022-07-04
 
 ## Added

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - SwiftFormat/CLI (0.47.2)
   - SwiftLint (0.40.3)
-  - TinkoffASDKCore (2.7.0)
-  - TinkoffASDKCore/Tests (2.7.0)
-  - TinkoffASDKUI (2.7.0):
+  - TinkoffASDKCore (2.8.0)
+  - TinkoffASDKCore/Tests (2.8.0)
+  - TinkoffASDKUI (2.8.0):
     - TinkoffASDKCore
 
 DEPENDENCIES:
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   SwiftFormat: 0315a7115b15fd4ea2d043d5f5c22e3c98f84078
   SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
-  TinkoffASDKCore: 096e25f7190ca4f0588291f82711f379d3eec2a4
-  TinkoffASDKUI: 22f02844f40bd51cd2b5f9a488310981519f372b
+  TinkoffASDKCore: f5c2037094420172d91ab5f03c39894024f9e5a6
+  TinkoffASDKUI: 8a23263a3645a45b7e6ee33b6e17f352eb0378cc
 
 PODFILE CHECKSUM: 66ce35bd53f36cb83613ba4b5ddae3c1ba9a0d71
 

--- a/TinkoffASDKCore/TinkoffASDKCore/AcquiringLogger.swift
+++ b/TinkoffASDKCore/TinkoffASDKCore/AcquiringLogger.swift
@@ -20,19 +20,19 @@
 import Foundation
 
 public protocol LoggerDelegate: AnyObject {
-    func log(_ value: String, file: String, function: String, line: Int)
+    func log(_ value: String, file: String, function: String, line: Int, thread: Thread)
 }
 
 public extension LoggerDelegate {
     func log(_ value: String, file: String = #file, function: String = #function, line: Int = #line) {
-        log(value, file: file, function: function, line: line)
+        log(value, file: file, function: function, line: line, thread: .current)
     }
 }
 
 public class AcquiringLoggerDefault: NSObject, LoggerDelegate {
-    public func log(_ value: String, file: String = #file, function: String = #function, line: Int = #line) {
+    public func log(_ value: String, file: String = #file, function: String = #function, line: Int = #line, thread: Thread = .current) {
         let fileName = file.split(separator: "/").last ?? ""
-        let threadName = Thread.isMainThread ? "main thread" : String(Thread.current.description)
+        let threadName = thread.isMainThread ? "Main thread" : thread.description
 
         Swift.print("[ASDK ->]: on \(threadName), in \(fileName), func \(function), at line: \(line) do:")
         Swift.print(value, separator: ", ", terminator: "\n")


### PR DESCRIPTION
В последнем релизе был переименован метод логгера print -> crash. У тех, кто использовал свою реализацию протокола LoggerDelegate в compile-time все будет в порядке, но непременно произойдет краш в рантайме из-за дефолтной имплементации протокола в extension. 

В этом ПР исправления этой оплошности