### PR TITLE
Добавлен пропущенный вызов completionHandler

### DIFF
--- a/TinkoffASDKUI/TinkoffASDKUI/AcquiringUISDK.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/AcquiringUISDK.swift
@@ -1248,6 +1248,15 @@ public class AcquiringUISDK: NSObject {
                                                         amount: paymentInitResponseData.amount,
                                                         status: .cancelled)
             onPaymentCompletionHandler?(.success(paymentResponse))
+        } else {
+            let paymentCanceledResponse = PaymentStatusResponse(success: false,
+                                                                errorCode: 0,
+                                                                errorMessage: AcqLoc.instance.localize("TinkoffAcquiring.alert.message.addingCardCancel"),
+                                                                orderId: "",
+                                                                paymentId: 0,
+                                                                amount: 0,
+                                                                status: .cancelled)
+            onPaymentCompletionHandler?(.success(paymentCanceledResponse))
         }
     }
 


### PR DESCRIPTION
Решение кейса, когда нужно обработать состояние отмены еще при пустой `paymentInitResponseData`
+решение этого [issue](https://github.com/Tinkoff/AcquiringSdk_IOS/issues/135)