### PR TITLE
[MIC-6099] Pay button touch handling with a recurrent payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+
+* [MIC-6099] The payment button touch handling in the payment form, with a recurring payment
+
 ## [2.8.1] - 2022-08-05Z
 
 ### Fixed

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - SwiftFormat/CLI (0.47.2)
   - SwiftLint (0.40.3)
-  - TinkoffASDKCore (2.8.0)
-  - TinkoffASDKCore/Tests (2.8.0)
-  - TinkoffASDKUI (2.8.0):
+  - TinkoffASDKCore (2.8.1)
+  - TinkoffASDKCore/Tests (2.8.1)
+  - TinkoffASDKUI (2.8.1):
     - TinkoffASDKCore
 
 DEPENDENCIES:
@@ -27,8 +27,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   SwiftFormat: 0315a7115b15fd4ea2d043d5f5c22e3c98f84078
   SwiftLint: dfd554ff0dff17288ee574814ccdd5cea85d76f7
-  TinkoffASDKCore: f5c2037094420172d91ab5f03c39894024f9e5a6
-  TinkoffASDKUI: 8a23263a3645a45b7e6ee33b6e17f352eb0378cc
+  TinkoffASDKCore: 1095d4be5b3f773382caccba0bf9f34304c92c18
+  TinkoffASDKUI: d09d39d953b39cf102b403feeb858dbff0fc00d9
 
 PODFILE CHECKSUM: 66ce35bd53f36cb83613ba4b5ddae3c1ba9a0d71
 

--- a/TinkoffASDKUI/TinkoffASDKUI/AcquiringPaymentViewController.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/AcquiringPaymentViewController.swift
@@ -501,9 +501,11 @@ extension AcquiringPaymentViewController: UITableViewDataSource {
                 }
 
                 cell.onButtonTouch = { [weak self] in
-                    if self?.validatePaymentForm() ?? false {
-                        self?.acquiringPaymentController?.performPayment()
-                    }
+                    guard let self = self,
+                          self.validatePaymentForm() else { return }
+
+                    let action = self.onTouchButtonPay ?? self.acquiringPaymentController?.performPayment
+                    action?()
                 }
 
                 return cell


### PR DESCRIPTION
Добавлен обработчик нажатия кнопки платежа при рекуррентном платеже с введением CVC. 
Вероятно ошибка закралась в код при интергации TinkoffPay