### PR TITLE
Fix xcode 14 compile error

### DIFF
--- a/TinkoffASDKUI/TinkoffASDKUI/CenterFlowLayout.swift
+++ b/TinkoffASDKUI/TinkoffASDKUI/CenterFlowLayout.swift
@@ -109,7 +109,9 @@ class CollectionViewCenteredFlowLayout: UICollectionViewFlowLayout {
                 }
                 let evaluatedSectionInset = evaluatedSectionInsetForSection(at: section)
                 let evaluatedMinimumInteritemSpacing = evaluatedMinimumInteritemSpacingForSection(at: section)
-                var origin = (collectionView.bounds.width + evaluatedSectionInset.left - evaluatedSectionInset.right - group.reduce(0) { $0 + $1.frame.size.width } - CGFloat(group.count - 1) * evaluatedMinimumInteritemSpacing) / 2
+                let groupWidth: CGFloat = group.reduce(0) { $0 + $1.frame.size.width }
+                var origin = (collectionView.bounds.width + evaluatedSectionInset.left - evaluatedSectionInset.right -
+                              groupWidth - CGFloat(group.count - 1) * evaluatedMinimumInteritemSpacing) / 2
                 // we reposition each element of a group
                 return group.map {
                     $0.frame.origin.x = origin
@@ -139,7 +141,8 @@ class CollectionViewCenteredFlowLayout: UICollectionViewFlowLayout {
                 }
                 let evaluatedSectionInset = evaluatedSectionInsetForSection(at: section)
                 let evaluatedMinimumInteritemSpacing = evaluatedMinimumInteritemSpacingForSection(at: section)
-                var origin = (collectionView.bounds.height + evaluatedSectionInset.top - evaluatedSectionInset.bottom - group.reduce(0) { $0 + $1.frame.size.height } - CGFloat(group.count - 1) * evaluatedMinimumInteritemSpacing) / 2
+                let groupWidth: CGFloat = group.reduce(0) { $0 + $1.frame.size.width }
+                var origin = (collectionView.bounds.height + evaluatedSectionInset.top - evaluatedSectionInset.bottom - groupWidth - CGFloat(group.count - 1) * evaluatedMinimumInteritemSpacing) / 2
                 // we reposition each element of a group
                 return group.map {
                     $0.frame.origin.y = origin


### PR DESCRIPTION
Fixes the error in XCode 14:
> The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions

<details>

![screenshot](https://user-images.githubusercontent.com/2203199/189493377-869c2cfe-81ea-45da-b177-7baccbe4c0cf.jpg)

</details>